### PR TITLE
Prepare for removal of `retype`.

### DIFF
--- a/packages/flutter_tools/lib/src/vmservice.dart
+++ b/packages/flutter_tools/lib/src/vmservice.dart
@@ -1348,7 +1348,8 @@ class ServiceMap extends ServiceObject implements Map<String, dynamic> {
   @override
   void updateAll(dynamic update(String key, dynamic value)) => _map.updateAll(update);
   @override
-  Map<RK, RV> retype<RK, RV>() => _map.retype<RK, RV>();  // ignore: deprecated_member_use
+  // ignore: override_on_non_overriding_method
+  Map<RK, RV> retype<RK, RV>() => _map.cast<RK, RV>();
   @override
   dynamic update(String key, dynamic update(dynamic value), {dynamic ifAbsent()}) => _map.update(key, update, ifAbsent: ifAbsent);
 }


### PR DESCRIPTION
The deprecated `retype` method is replaced by `cast`, and will be removed.
When that happens, the `retype` method here will no longer be overriding, and can then be.